### PR TITLE
Déplacement tâches vers Celery

### DIFF
--- a/esg-api/Taskfile.yml
+++ b/esg-api/Taskfile.yml
@@ -6,5 +6,5 @@ tasks:
   format: ruff format 
   lint: ruff check 
   fix: ruff check --fix
-  celery: celery -A flask_app.tasks worker --loglevel=info
+  celery: celery -A flask_app.tasks worker --loglevel=info --pool=threads
   dev: honcho start --procfile Procfile.dev

--- a/esg-api/src/flask_app/__init__.py
+++ b/esg-api/src/flask_app/__init__.py
@@ -26,6 +26,8 @@ MODEL_FILE_PATH = MODEL_PATH + MODEL_NAME
 CURRENT_DEVICE = "cpu"
 MODELS = []
 
+# Endpoint de l'application Portail RSE 
+APP_BASE_URL = os.getenv("APP_BASE_URL")
 
 # Flask & Celery
 MAX_CONTENT_LENGTH = 100 * 1024 * 1024  # < 100 MB

--- a/esg-api/src/flask_app/__init__.py
+++ b/esg-api/src/flask_app/__init__.py
@@ -10,7 +10,7 @@ CURRENT_FULL_PATH = os.getcwd()
 # File names
 TEXT_FILE_NAME_PKL = "texts_file.pkl"
 TEXT_FILE_NAME_CSV = "texts_file.csv"
-PRED_FILE_NAME_CSV = "esrs_preds.csv"
+PRED_FILE_NAME_JSON = "esrs_preds.json"
 
 # HuggingFace model name and repo name
 MODEL_NAME = "distill-camembert-esrs-v1"

--- a/esg-api/src/flask_app/app.py
+++ b/esg-api/src/flask_app/app.py
@@ -29,7 +29,7 @@ from flask_app import init_flask_app
 # voir :__init__.py
 from flask_app import (
     CURRENT_FULL_PATH,
-    PRED_FILE_NAME_CSV,
+    PRED_FILE_NAME_JSON,
     WS_PATH,
     TEXT_FILE_NAME_CSV,
     TEXT_FILE_NAME_PKL,
@@ -267,7 +267,7 @@ def esrspredict(pdf_key, pdf_path):
 def getpredsfile(pdf_key, pdf_path):
     # Get texts csv file from pdf path
     csv_file_path = (
-        str(CURRENT_FULL_PATH) + "/" + str(pdf_path) + "/" + PRED_FILE_NAME_CSV
+        str(CURRENT_FULL_PATH) + "/" + str(pdf_path) + "/" + PRED_FILE_NAME_JSON
     )
 
     try:

--- a/esg-api/src/flask_app/app.py
+++ b/esg-api/src/flask_app/app.py
@@ -333,8 +333,10 @@ def run_task():
     document_id = request.form["document_id"]
     s3_url = request.form["url"]
     response = requests.get(s3_url)
-    pdf_path = f"{WS_PATH}/pdf_{document_id}.pdf"
-    with open(pdf_path, "wb") as f:
+    pdf_path = f"{WS_PATH}/document_{document_id}"
+    os.makedirs(pdf_path, exist_ok=True)
+    file_path = f"{pdf_path}/fichier.pdf"
+    with open(file_path, "wb") as f:
         f.write(response.content)
-    tasks.esrspredict.delay(document_id, pdf_path)
+    tasks.analyser.delay(document_id, pdf_path)
     return json_response({"status": "en attente"})

--- a/esg-api/src/flask_app/tasks.py
+++ b/esg-api/src/flask_app/tasks.py
@@ -181,7 +181,7 @@ def esrspredict(pdf_key, pdf_path) -> dict:
             # Save predictions to CSV file
             texts_esrs = [model.labels_names[k] for k in y_preds]
             pd_texts.loc[:, "ESRS"] = texts_esrs
-            pd_texts.to_json(json_file_path, index=False)
+            pd_texts.groupby("ESRS")[["PAGES", "TEXTS"]].apply(lambda x: x.to_dict(orient='records')).to_json(json_file_path)
 
         else:
             msg = "Pas de texte à analyser"

--- a/esg-api/src/flask_app/tasks.py
+++ b/esg-api/src/flask_app/tasks.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from pathlib import PosixPath
 
 import pandas as pd
 import requests
@@ -12,9 +13,11 @@ from flask_app import (
     MODEL_FILE_PATH,
     PRED_FILE_NAME_CSV,
     REPO_NAME,
+    TEXT_FILE_NAME_CSV,
     TEXT_FILE_NAME_PKL,
     init_flask_app,
 )
+from helpers.extract import ExtractTexts
 
 flask_app = init_flask_app()
 celery = flask_app.extensions["celery"]
@@ -48,6 +51,79 @@ def init_model():
 
 
 @shared_task(ignore_result=False)
+def analyser(document_id, pdf_path):
+    url = f"{APP_BASE_URL}/ESRS-predict/{document_id}"
+    requests.post(url, {"status": "analyse en cours"})
+
+    pdf2txt(document_id, pdf_path)
+    esrspredict(document_id, pdf_path)
+    sendpredsfile(document_id, pdf_path)
+
+def pdf2txt(pdf_key, pdf_path):
+    # Paths to PDF file
+    PDFs_DIR = PosixPath(pdf_path)
+    pdfs = list(PDFs_DIR.glob("*.pdf"))
+    pdf = pdfs[0]
+
+    # Path to texts files
+    file_path = str(CURRENT_FULL_PATH) + "/" + str(pdf_path) + "/"
+
+    # Path to the token directory
+    PDF_FILE_PATH = str(CURRENT_FULL_PATH) + "/" + str(pdf)
+
+    try:
+        # Create extractor
+        es = ExtractTexts(PDF_FILE_PATH)  # , 10, 30)
+
+        # Run extractor
+        pd_res = es.process()
+
+        # Filter some texts
+        if len(pd_res) > 0:
+            # Add indicators
+            pd_res.loc[:, "segment_nb_words"] = pd_res.segment_text.apply(
+                lambda x: len(x.split())
+            )
+            pd_res["number_percent"] = pd_res.segment_text.str.count(r"%")
+            pd_res["number_rc"] = pd_res.segment_text.str.count(r"\n")
+            pd_res["number_tiret"] = pd_res.segment_text.str.count(r"-")
+            pd_res["number_count"] = pd_res.segment_text.str.count(r"\d")
+            pd_res["char_count"] = pd_res.segment_text.str.replace(
+                r"\s+", "", regex=True
+            ).str.len()
+            pd_res["number_ratio"] = pd_res["number_count"] / pd_res["char_count"]
+
+            # Filtering indicators
+            pd_res_filter = pd_res.query(
+                "segment_nb_words > 20 and segment_nb_words < 500"
+            )
+            pd_res_filter = pd_res_filter.query("number_ratio < 0.2")
+            pd_res_filter = pd_res_filter.query("number_rc < 10")
+            pd_res_filter = pd_res_filter.query("number_percent < 5")
+            pd_res_filter = pd_res_filter.query("number_tiret < 6")
+            pd_res_filter.segment_text = pd_res_filter.segment_text.str.replace(
+                "\xa0", " "
+            )
+            pd_res_filter = pd_res_filter.loc[:, ["page_num", "segment_text"]]
+            pd_res_filter.columns = ["PAGES", "TEXTS"]
+
+            # Save Texts to Pickle and CSV
+            pd_res_filter.to_pickle(file_path + TEXT_FILE_NAME_PKL)
+            pd_res_filter.to_csv(file_path + TEXT_FILE_NAME_CSV, index=False)
+
+            # Return OK and the number of texts
+            nbtexts = pd_res_filter.shape[0]
+            status_dict = {"code": 1, "msg": f"{nbtexts} texts found in PDF"}
+        else:
+            nbtexts = 0
+            status_dict = {"code": -2, "msg": "No text found in PDF"}
+
+    except Exception as e:
+        nbtexts = 0
+        status_dict = {"code": -1, "msg": f"Can't convert PDF to TXT {e}"}
+
+    logger.info(f"fin pdf2txt pour {pdf_key} : {status_dict}")
+
 def esrspredict(pdf_key, pdf_path):
     status_dict = {"code": 0, "msg": "ESRS predicted with success"}
 
@@ -93,5 +169,14 @@ def esrspredict(pdf_key, pdf_path):
 
     logger.info(f"fin d'analyse pour {pdf_key} : {status_dict}")
 
+
+def sendpredsfile(pdf_key, pdf_path):
+    csv_file_path = (
+        str(CURRENT_FULL_PATH) + "/" + str(pdf_path) + "/" + PRED_FILE_NAME_CSV
+    )
+    with open(csv_file_path) as f:
+        content = f.read()
     url = f"{APP_BASE_URL}/ESRS-predict/{pdf_key}"
-    requests.post(url, {"status": "analyse en cours"})
+    requests.post(url, {"status": "success", "resultat_csv": content})
+
+    logger.info(f"fin sendpredsfile pour {pdf_key}")

--- a/esg-api/src/flask_app/tasks.py
+++ b/esg-api/src/flask_app/tasks.py
@@ -12,7 +12,7 @@ from celery import shared_task
 from flask_app import (
     CURRENT_FULL_PATH,
     MODEL_FILE_PATH,
-    PRED_FILE_NAME_CSV,
+    PRED_FILE_NAME_JSON,
     REPO_NAME,
     TEXT_FILE_NAME_CSV,
     TEXT_FILE_NAME_PKL,
@@ -154,8 +154,8 @@ def esrspredict(pdf_key, pdf_path) -> dict:
     pkl_file_path = (
         str(CURRENT_FULL_PATH) + "/" + str(pdf_path) + "/" + TEXT_FILE_NAME_PKL
     )
-    csv_file_path = (
-        str(CURRENT_FULL_PATH) + "/" + str(pdf_path) + "/" + PRED_FILE_NAME_CSV
+    json_file_path = (
+        str(CURRENT_FULL_PATH) + "/" + str(pdf_path) + "/" + PRED_FILE_NAME_JSON
     )
 
     msg = pkl_file_path
@@ -181,7 +181,7 @@ def esrspredict(pdf_key, pdf_path) -> dict:
             # Save predictions to CSV file
             texts_esrs = [model.labels_names[k] for k in y_preds]
             pd_texts.loc[:, "ESRS"] = texts_esrs
-            pd_texts.to_csv(csv_file_path, index=False)
+            pd_texts.to_json(json_file_path, index=False)
 
         else:
             msg = "Pas de texte à analyser"
@@ -193,7 +193,7 @@ def esrspredict(pdf_key, pdf_path) -> dict:
 
 def sendpredsfile(pdf_key, pdf_path) -> dict:
     csv_file_path = (
-        str(CURRENT_FULL_PATH) + "/" + str(pdf_path) + "/" + PRED_FILE_NAME_CSV
+        str(CURRENT_FULL_PATH) + "/" + str(pdf_path) + "/" + PRED_FILE_NAME_JSON
     )
 
     with open(csv_file_path) as f:
@@ -201,8 +201,7 @@ def sendpredsfile(pdf_key, pdf_path) -> dict:
 
     logger.info(f"fin sendpredsfile pour {pdf_key}")
 
-    # TODO : JSON
-    return make_status(pdf_key, "success", resultat_csv=content)
+    return make_status(pdf_key, "success", resultat_json=content)
 
 
 @shared_task(ignore_result=False)


### PR DESCRIPTION
On regroupe les différentes phases de traitements de la partie synchrone : 
- extraction du texte du PDF et stockage
- nettoyage  
- analyse
dans une même tâche Celery, avec des callbacks vers l'app à chaque étape.

Les résultats ne sont plus stockés en PDF mais au format JSON qui devrait être plus facile à traiter coté app.

Un peu de nettoyage du code au passage.