### PR TITLE
URL signalant l'état du traitement fourni par le client de l'API

### DIFF
--- a/esg-api/src/flask_app/__init__.py
+++ b/esg-api/src/flask_app/__init__.py
@@ -26,9 +26,6 @@ MODEL_FILE_PATH = MODEL_PATH + MODEL_NAME
 CURRENT_DEVICE = "cpu"
 MODELS = []
 
-# Endpoint de l'application Portail RSE
-APP_BASE_URL = os.getenv("APP_BASE_URL")
-
 # Pour la gestion des tokens JWT
 JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY")
 

--- a/esg-api/src/flask_app/app.py
+++ b/esg-api/src/flask_app/app.py
@@ -55,13 +55,14 @@ def run_task():
     logger.info("params:", request.form)
     try:
         document_id = request.form["document_id"]
-        s3_url = request.form["url"]
+        s3_url = request.form["document_url"]
+        callback_url = request.form["callback_url"]
         pdf_path = _fetch_s3_document(s3_url, document_id)
     except Exception as ex:
         logger.exception(ex)
         return jsonify({"status": "error", "msg": str(ex)})
     else:
         # à ce point, les erreurs sont gérées par la tâche Celery
-        tasks.analyser.delay(document_id, pdf_path)
+        tasks.analyser.delay(document_id, pdf_path, callback_url)
 
         return jsonify({"status": "en attente"})

--- a/esg-api/src/flask_app/tasks.py
+++ b/esg-api/src/flask_app/tasks.py
@@ -35,7 +35,7 @@ def make_status(document_id: str, status: str, **kwargs) -> dict:
 
 
 def notify_app(callback_url: str, status: dict):
-    # appelle l'URL de callbach avec le statut d'avancement actuel
+    # appelle l'URL de callback avec le statut d'avancement actuel
     
     logger.debug(f"URL de notification : {callback_url}")
     logger.debug(f"contenu de la notification : {status}")


### PR DESCRIPTION
L'API change légèrement pour fournir une URL signalant l'état du traitement fourni par le client de l'API.
    
 - Permet d'utiliser une instance de l'API par plusieurs services (recette et production par exemple).
 - Permet de modifier l'URL dans le futur sans modifier le service (ni le code, ni une variable d'environnement)
