### PR TITLE
suppression de APP_BASE_URL de l'exemple

### DIFF
--- a/esg-api/example.env
+++ b/esg-api/example.env
@@ -2,5 +2,4 @@ PYTHONPATH=.:src
 HF_TOKEN=my-hugging-face-token
 CELERY_BROKER_URL=redis://localhost:6379/0
 CELERY_RESULT_BACKEND=redis://localhost:6379/0
-APP_BASE_URL=http://localhost:5000
 JWT_SECRET_KEY=my-very-secret-key


### PR DESCRIPTION
Cette variable d'environnement est maintenant inutile.