### PR TITLE
Maj image docker flask

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,3 @@ Execute à la fois les commandes de lancement des workers Celery et de l'applica
 ```
 task dev
 ```
-
-### Utiliser le notebook
-
-```
-jupyter notebook esg-api/notebook/detect_api_in_jupyter.ipynb
-```

--- a/esg-api/Dockerfile
+++ b/esg-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bookworm
+FROM python:3.12-trixie-bookworm
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 


### PR DESCRIPTION
Passe de bookworm à trixie
Permet de valider le deploiement via deploy.sh (cf. esg-api/README.md)

La liste des images python montre des versions de python plus récentes si besoin:
https://hub.docker.com/_/python