### PR TITLE
Correction traitement pdf sans texte

### DIFF
--- a/esg-api/src/flask_app/app.py
+++ b/esg-api/src/flask_app/app.py
@@ -14,7 +14,7 @@ import logging
 import os
 
 import requests
-from flask import abort, request, jsonify
+from flask import request, jsonify
 from flask_jwt_extended import JWTManager, jwt_required
 from flasgger import Swagger
 

--- a/esg-api/src/flask_app/tasks.py
+++ b/esg-api/src/flask_app/tasks.py
@@ -168,6 +168,12 @@ def pdf2txt(pdf_key, pdf_path) -> dict:
 
             # Return OK and the number of texts
             nbtexts = pd_res_filter.shape[0]
+        else:
+            return make_status(
+                pdf_key,
+                "error",
+                msg="Aucune phrase trouvée dans le PDF",
+            )
     except Exception as e:
         msg_utilisateur = "Erreur lors de l’extraction des phrases à analyser"
         msg = f"{msg_utilisateur} : {e}"


### PR DESCRIPTION
Si aucune phrase n'est trouvée, il est inutile de continuer l'analyse du fichier.

Indique à l'utilisateur l'erreur (par exemple s'il a simplement inséré une image dans un pdf).